### PR TITLE
chore: Remove duplicate uploads

### DIFF
--- a/src/submission-forwarder/documentsToS3Storage/DocumentsToS3StorageHandler.ts
+++ b/src/submission-forwarder/documentsToS3Storage/DocumentsToS3StorageHandler.ts
@@ -1,9 +1,9 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 import { S3Client } from '@aws-sdk/client-s3';
+import { Submission } from '../shared/Submission';
 import { FileDownloader } from './FileDownloader';
 import { s3PathsFromFileData } from './s3PathsFromFileData';
 import { S3Uploader } from './S3Uploader';
-import { Submission } from '../shared/Submission';
 
 
 export interface DocumentsToS3StorageHandlerOptions {
@@ -30,11 +30,11 @@ export class DocumentsToS3StorageHandler {
     const fileData = await Promise.all(promises);
     await this.options.s3Uploader.storeBulk(submission.reference, fileData);
 
-    const files = s3PathsFromFileData(fileData, this.options.bucketName, submission.reference);
+    const filePaths = s3PathsFromFileData(fileData, this.options.bucketName, submission.reference);
 
     return {
       submission,
-      files,
+      filePaths,
     };
   }
 }

--- a/src/submission-forwarder/forwarder-lambda/Handler.ts
+++ b/src/submission-forwarder/forwarder-lambda/Handler.ts
@@ -23,6 +23,7 @@ interface SubmissionForwarderHandlerOptions {
   queueUrl: string;
 }
 
+
 export class SubmissionForwarderHandler {
 
 
@@ -31,7 +32,7 @@ export class SubmissionForwarderHandler {
    */
   constructor(private readonly options: SubmissionForwarderHandlerOptions) { }
 
-  async handle(submission: Submission) {
+  async handle(submission: Submission, filePaths: string[]) {
 
     // Message is the submission
     logger.debug('Retreived submisison', { submission });
@@ -47,12 +48,11 @@ export class SubmissionForwarderHandler {
     const documentenClient = new documenten.Enkelvoudiginformatieobjecten(httpClient);
 
     // Download PDF, Attachments and create save files in S3 bucket. On retry overwritten.
-    const pdfS3Url = await this.downloadPdf(submission, documentenClient);
-    const attachmentS3Urls = await this.downloadAttachments(submission, documentenClient);
+    // const pdfS3Url = await this.downloadPdf(submission, documentenClient);
+    // const attachmentS3Urls = await this.downloadAttachments(submission, documentenClient);
     const saveFileS3Urls = await this.createSaveFiles(submission);
     const s3Files: string[] = [
-      pdfS3Url,
-      ...attachmentS3Urls,
+      ...filePaths,
       ...saveFileS3Urls,
     ];
 

--- a/src/submission-forwarder/forwarder-lambda/forwarder.lambda.ts
+++ b/src/submission-forwarder/forwarder-lambda/forwarder.lambda.ts
@@ -1,8 +1,8 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 import { environmentVariables } from '@gemeentenijmegen/utils';
-import { SubmissionForwarderHandler } from './Handler';
 import { SubmissionSchema } from '../shared/Submission';
 import { ZgwClientFactory } from '../shared/ZgwClientFactory';
+import { SubmissionForwarderHandler } from './Handler';
 
 const logger = new Logger();
 
@@ -30,8 +30,9 @@ export async function handler(event: any) {
     queueUrl: env.QUEUE_URL,
   });
 
-  const submission = SubmissionSchema.parse(event);
-  await submissionForwarderHandler.handle(submission);
+  const submission = SubmissionSchema.parse(event.submission);
+  const filePaths = event.filePaths;
+  await submissionForwarderHandler.handle(submission, filePaths);
 
 }
 

--- a/src/submission-forwarder/orchestration.asl.json
+++ b/src/submission-forwarder/orchestration.asl.json
@@ -67,7 +67,6 @@
     "Store files in S3": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
-      "Output": "{% $states.input %}",
       "Arguments": {
         "FunctionName": "${S3_STORAGE_LAMBDA_ARN}",
         "Payload": "{% $states.input %}"
@@ -91,7 +90,7 @@
     "ESB Forwarder": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
-      "Output": "{% $states.input %}",
+      "Output": "{% $states.input.submission %}",
       "Arguments": {
         "FunctionName": "${FORWARDER_LAMBDA_ARN}",
         "Payload": "{% $states.input %}"


### PR DESCRIPTION
- S3-storage is now handled by a separate step. Submission PDF and attachments are stored in S3 by this step. (SaveFiles are NOT). this removes that function from the generic forwarder.
- The forwarder now receives submission + filepaths, and uses those to create the message to ESB.
- The forwarder only forwards the submission object.
