### PR TITLE
feat: parse multiple objecttypes

### DIFF
--- a/src/submission-forwarder/SubmissionForwarder.ts
+++ b/src/submission-forwarder/SubmissionForwarder.ts
@@ -61,6 +61,7 @@ export class SubmissionForwarder extends Construct {
     catalogiApiBaseUrl: StringParameter;
     mijnServicesOpenZaakApiClientId: StringParameter;
     mijnServicesOpenZaakApiClientSecret: Secret;
+    supportedObjectTypes: StringParameter;
   };
 
   constructor(scope: Construct, id: string, private readonly options: SubmissionForwarderOptions) {
@@ -143,6 +144,8 @@ export class SubmissionForwarder extends Construct {
       description: 'Client secret used by submission-forwarder to authenticate at mijn services open zaak APIs',
     });
 
+    const additionalParameters = new ForwarderParameters(this, 'params');
+
     return {
       apikey,
       objectsApikey,
@@ -151,6 +154,7 @@ export class SubmissionForwarder extends Construct {
       catalogiApiBaseUrl,
       mijnServicesOpenZaakApiClientId,
       mijnServicesOpenZaakApiClientSecret,
+      supportedObjectTypes: additionalParameters.supportedObjectTypes,
     };
   }
 
@@ -174,6 +178,7 @@ export class SubmissionForwarder extends Construct {
         MIJN_SERVICES_OPEN_ZAAK_CLIENT_SECRET_ARN: this.parameters.mijnServicesOpenZaakApiClientSecret.secretArn,
         OBJECTS_API_APIKEY_ARN: this.parameters.objectsApikey.secretArn,
         ORCHESTRATOR_ARN: orchestrator.stateMachineArn,
+        SUPPORTED_OBJECTTYPES: this.parameters.supportedObjectTypes.stringValue,
       },
     });
     this.parameters.apikey.grantRead(receiver);
@@ -475,4 +480,19 @@ export class SubmissionForwarder extends Construct {
 
   }
 
+}
+
+class ForwarderParameters extends Construct {
+  public supportedObjectTypes: StringParameter;
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.addForwarderParameters();
+  }
+
+  addForwarderParameters() {
+    this.supportedObjectTypes = new StringParameter(this, 'objectTypes', {
+      stringValue: 'submission:https://example.com/objecttypes/api/v2/objecttypes/d3713c2b-307c-4c07-8eaa-c2c6d75869cf,esftaak:https://example.com/objecttypes/api/v2/objecttypes/6df21057-e07c-4909-8933-d70b79cfd15e',
+      description: 'name:url pairs (comma-separated) defining supported objecttypes',
+    });
+  }
 }

--- a/src/submission-forwarder/docs/README.md
+++ b/src/submission-forwarder/docs/README.md
@@ -11,14 +11,30 @@ Zie ook:
 ### Details ESB integratie
 De ESB heeft een interne retry en kan berichten op de AWS DLQ zetten wanneer afhandeling aan de ESB kant niet lukt. Wij kunnen een redrive doen om berichten opnieuw bij de ESB in te dienen.
 
-
 ### Details voor formulier beheerders
 - In OpenFormulieren blijven inzendingen (als ze zijn doorgestuurd) nog 7 dagen staan. Als het doorsturen naar een registratie systeem faalt blijven formulieren 30 dagen staan.
 - Er is een interne backup ingebouwd (net als bij de oude webformulieren). De resubmit lambda bestaat nog niet. Hier blijven inzendingen 90 dagen bewaard. Dit is alleen het AWS SQS bericht, de documenten blijven in de documenten API.
 
 
-## Objecttype
-Het schema dat we gebruiken voor het objecttype kan je [hier vinden](../schema/netwerkschijfESBFormulierInzending.json).
+## Objecttypes
+Het schema dat we gebruiken voor het submission objecttype kan je [hier vinden](../schema/netwerkschijfESBFormulierInzending.json).
+
+Er is support voor meerdere objecttypes:
+
+For the ability to send on multiple object types to the step function,
+we need to support more than the submission object.
+
+The step function will receive an object with at least pdf, attachments and 
+reference keys.
+
+For determining object type, an SSM parameter is available: This contains
+the supported object types, in a format like this:
+
+`<objectType>##<objectTypeUrl>;<objectType>##<objectTypeUrl>`
+
+This only supports for <objectType> values from 
+`ObjectParser.supportedObjectTypes`. All unsupported objects are 
+ignored.
 
 ## Submission trace
 Er is een tabel (dynamodb) waarin alle lambda's een trace record wegschrijven als ze een verwerking hebben gedaan van een submission. De key is dan het submission ID en het handler ID (bijv. `receiver` of `esb_forwarder`). De sortkey is een timestamp. 

--- a/src/submission-forwarder/receiver-lambda/ErrorTypes.ts
+++ b/src/submission-forwarder/receiver-lambda/ErrorTypes.ts
@@ -1,3 +1,4 @@
 
 export class ParseError extends Error { }
 export class SendMessageError extends Error { }
+export class UnknownObjectError extends Error { }

--- a/src/submission-forwarder/receiver-lambda/ObjectParser.ts
+++ b/src/submission-forwarder/receiver-lambda/ObjectParser.ts
@@ -1,0 +1,86 @@
+import { UnknownObjectError } from './ErrorTypes';
+import { EsfTaak, EsfTaakSchema } from '../shared/EsfTaak';
+import { Submission, SubmissionSchema } from '../shared/Submission';
+import { ZgwObject } from '../shared/ZgwObject';
+
+export interface objectParserResult {
+  pdf?: string;
+  attachments?: string[];
+  reference: string;
+  [key: string]: any;
+}
+interface objectType {
+  objectTypeUrl: string;
+  parser: any;
+};
+
+/**
+ * The Object parser takes an object from the Objects API,
+ * validates its one of the accepted types, and if necessary
+ * parses it int a standard format, keeping data but making sure
+ * a reference, pdf (if relevant) and attachments (if relevant)
+ * are available at the top level.
+ */
+export class ObjectParser {
+  private objectTypes: objectType[];
+
+  private supportedObjectTypes = {
+    esfTaak: EsfTaakSchema,
+    submission: SubmissionSchema,
+  };
+
+  constructor(objectTypes: objectType[] | string) {
+    if (Array.isArray(objectTypes)) {
+      this.objectTypes = objectTypes;
+    } else {
+      this.objectTypes = this.parseObjectTypestring(objectTypes);
+    }
+  }
+
+  parse(object: ZgwObject): objectParserResult {
+    const type = this.objectTypes.find(objectType => objectType.objectTypeUrl == object.type);
+    if (!type) {
+      throw new UnknownObjectError('Unknown object type, unable to parse');
+    }
+    const parsed = type.parser.parse(object.record.data);
+    if (type.parser == SubmissionSchema) {
+      let submission = parsed as Submission;
+      return submission;
+    } else if (type.parser == EsfTaakSchema) {
+      let taak = parsed as EsfTaak;
+      return {
+        pdf: taak.formtaak.verzonden_data.pdf,
+        attachments: taak.formtaak.verzonden_data.attachments,
+        reference: `EFS-${taak.formtaak.data.dossiernummer}-${taak.formtaak.data.periodenummer}`,
+        taak,
+      };
+    }
+    throw new UnknownObjectError('Unexpectedly reached end of parser');
+  }
+
+  /**
+   *  Parses string to objecttypes (for passing in .env)
+   *
+   *  String are expected to be of format: <name>##<objecttypeurl> and ; separated
+   *  Names can only be those specified in `this.supportedParsers`
+   *
+   *  example: `esftaak##https://example.com/someuuid;submission##https://example.com/somethingelse`
+   */
+  parseObjectTypestring(objectTypes: string) {
+    const types = Object.keys(this.supportedObjectTypes);
+    const partsStrings = objectTypes
+      .split(';')
+      .map(part => part.split('##'));
+    return partsStrings.map(part => {
+      if (types.includes(part[0])) {
+        const myType = part[0] as keyof typeof this.supportedObjectTypes;
+        return {
+          objectTypeUrl: part[1],
+          parser: this.supportedObjectTypes[myType],
+        };
+      } else {
+        return null;
+      }
+    }).filter(value => value != null);
+  }
+}

--- a/src/submission-forwarder/receiver-lambda/receiver.lambda.ts
+++ b/src/submission-forwarder/receiver-lambda/receiver.lambda.ts
@@ -1,9 +1,9 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 import { environmentVariables } from '@gemeentenijmegen/utils';
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { ZgwClientFactory } from '../shared/ZgwClientFactory';
 import { authenticate } from './authenticate';
 import { ReceiverHandler } from './Handler';
+import { ZgwClientFactory } from '../shared/ZgwClientFactory';
 
 const logger = new Logger();
 
@@ -37,7 +37,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     zgwClientFactory: getZgwClientFactory(),
     topicArn: env.TOPIC_ARN,
     orchestratorArn: env.ORCHESTRATOR_ARN,
-    supportedObjectTypes: env.SUPPORTED_OBJECTTYPES
+    supportedObjectTypes: env.SUPPORTED_OBJECTTYPES,
   });
 
   try {

--- a/src/submission-forwarder/receiver-lambda/receiver.lambda.ts
+++ b/src/submission-forwarder/receiver-lambda/receiver.lambda.ts
@@ -1,9 +1,9 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 import { environmentVariables } from '@gemeentenijmegen/utils';
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ZgwClientFactory } from '../shared/ZgwClientFactory';
 import { authenticate } from './authenticate';
 import { ReceiverHandler } from './Handler';
-import { ZgwClientFactory } from '../shared/ZgwClientFactory';
 
 const logger = new Logger();
 
@@ -14,6 +14,7 @@ const env = environmentVariables([
   'MIJN_SERVICES_OPEN_ZAAK_CLIENT_SECRET_ARN',
   'OBJECTS_API_APIKEY_ARN',
   'ORCHESTRATOR_ARN',
+  'SUPPORTED_OBJECTTYPES',
 ]);
 
 function getZgwClientFactory() {
@@ -36,6 +37,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     zgwClientFactory: getZgwClientFactory(),
     topicArn: env.TOPIC_ARN,
     orchestratorArn: env.ORCHESTRATOR_ARN,
+    supportedObjectTypes: env.SUPPORTED_OBJECTTYPES
   });
 
   try {

--- a/src/submission-forwarder/receiver-lambda/test/objectParser.test.ts
+++ b/src/submission-forwarder/receiver-lambda/test/objectParser.test.ts
@@ -1,0 +1,58 @@
+import { EsfTaakSchema } from '../../shared/EsfTaak';
+import { SubmissionSchema } from '../../shared/Submission';
+import { ObjectParser } from '../ObjectParser';
+import * as taak from './samples/esfTaak.json';
+import * as randomObject from './samples/randomObject.json';
+import * as submission from './samples/submission.json';
+
+const esfTaakUrl = 'https://example.com/objecttypes/api/v2/objecttypes/6df21057-e07c-4909-8933-d70b79cfd15e';
+const submissionTaakUrl = 'https://example.com/objecttypes/api/v2/objecttypes/d3713c2b-307c-4c07-8eaa-c2c6d75869cf';
+
+let objectParser: ObjectParser;
+beforeAll(() => {
+  const objectTypes = [
+    {
+      objectTypeUrl: submissionTaakUrl,
+      parser: SubmissionSchema,
+    },
+    {
+      objectTypeUrl: `${esfTaakUrl}`,
+      parser: EsfTaakSchema,
+    },
+  ];
+  objectParser = new ObjectParser(objectTypes);
+});
+
+describe('Parsing for the next step', () => {
+  test('Parsing a taak object succeeds', async () => {
+    expect(objectParser.parse(taak)).toBeTruthy();
+  });
+  test('Parsing a submission object succeeds', async () => {
+    expect(objectParser.parse(submission)).toBeTruthy();
+  });
+
+  test('Parsing an unknown object throws', async () => {
+    expect(() => { objectParser.parse(randomObject); }).toThrow();
+  });
+});
+
+
+describe('Parsing urls from env var', () => {
+  const envStringEsfTaak = `esfTaak##${esfTaakUrl}`;
+  const envStringSubmission = `submission##${submissionTaakUrl}`;
+  const envStringBoth = `${envStringEsfTaak};${envStringSubmission}`;
+
+  test('Parsing the string (single)', async() => {
+    const parsed = objectParser.parseObjectTypestring(envStringEsfTaak);
+    expect(parsed.length).toBe(1);
+    expect(parsed[0].objectTypeUrl).toBe(`${esfTaakUrl}`);
+  });
+
+  test('Parsing the string (multiple)', async() => {
+    const parsed = objectParser.parseObjectTypestring(envStringBoth);
+    expect(parsed.length).toBe(2);
+    expect(parsed[0].objectTypeUrl).toBe(`${esfTaakUrl}`);
+    expect(parsed[1].objectTypeUrl).toBe(`${submissionTaakUrl}`);
+    expect(parsed[1].parser).toBe(SubmissionSchema);
+  });
+});

--- a/src/submission-forwarder/receiver-lambda/test/receiver.test.ts
+++ b/src/submission-forwarder/receiver-lambda/test/receiver.test.ts
@@ -39,6 +39,7 @@ describe('receiver', () => {
   let fakeHttpClient: any = {};
   let fakeObjectsApiClient: any = {
     getObject: jest.fn().mockResolvedValue({
+      type: 'https://example.com/objecturl',
       record: { data: fakeSubmission },
     }),
   };
@@ -56,6 +57,7 @@ describe('receiver', () => {
       zgwClientFactory: fakeZgwClientFactory as any,
       topicArn: 'arn:topci:aws:somewhere',
       orchestratorArn: 'arn:topci:aws:somewhere',
+      supportedObjectTypes: 'submission##https://example.com/objecturl',
     });
 
   });
@@ -65,6 +67,7 @@ describe('receiver', () => {
       zgwClientFactory: fakeZgwClientFactory as any,
       topicArn: 'arn:topci:aws:somewhere',
       orchestratorArn: 'arn:topci:aws:somewhere',
+      supportedObjectTypes: 'submission##https://example.com/objecturl',
     });
     await handler.handle(fakeEvent as any);
 

--- a/src/submission-forwarder/receiver-lambda/test/samples/esfTaak.json
+++ b/src/submission-forwarder/receiver-lambda/test/samples/esfTaak.json
@@ -1,0 +1,52 @@
+{
+  "type": "https://example.com/objecttypes/api/v2/objecttypes/6df21057-e07c-4909-8933-d70b79cfd15e",
+  "record": {
+    "typeVersion": 3,
+    "data": {
+      "soort": "formtaak",
+      "titel": "Statusformulier invullen",
+      "status": "open",
+      "eigenaar": "nijmegen",
+      "formtaak": {
+        "formulier": {
+          "soort": "url",
+          "value": "https://example.com/statusformulier"
+        },
+        "data": {
+          "dossiernummer": "dossier-test-1",
+          "periodenummer": "202506",
+          "email": "test@example.com",
+          "telefoon": "1234567890"
+        },
+        "verzonden_data": {
+          "pdf": "https://example.com/documenten/api/v1/enkelvoudiginformatieobjecten/e73ea0f5-2088-4f75-b862-5ebc962e8f47",
+          "email": "test@example.com",
+          "telefoon": "1234567891",
+          "attachments": [],
+          "studiegewijzigd": "nee",
+          "vakantiegewijzigd": "nee",
+          "vermogengewijzigd": "nee",
+          "inkomstengewijzigd": "nee",
+          "woonsituatiegewijzigd": "nee",
+          "vrijwilligerswerkgewijzigd": "nee"
+      }
+      },
+      "koppeling": {
+        "uuid": "4c9b685d-3a9c-4216-9bb8-cac7fb2456e1",
+        "registratie": "zaak"
+      },
+      "verloopdatum": "2025-05-21 00:00:00",
+      "identificatie": {
+        "type": "bsn",
+        "value": "900026236"
+      },
+      "verwerker_taak_id": "client_task"
+    },
+    "geometry": null,
+    "startAt": "2025-05-26",
+    "endAt": null,
+    "registrationAt": "2025-05-26",
+    "correctionFor": null,
+    "correctedBy": null
+  }
+}

--- a/src/submission-forwarder/receiver-lambda/test/samples/randomObject.json
+++ b/src/submission-forwarder/receiver-lambda/test/samples/randomObject.json
@@ -1,0 +1,18 @@
+{
+  "url": "https://example.com/objects/api/v2/objects/5a02c14e",
+  "uuid": "5a02c14e",
+  "type": "https://example.com/objecttypes/api/v2/objecttypes/somethingelse",
+  "record": {
+    "index": 1,
+    "typeVersion": 3,
+    "data": {
+      "somekey": "somevalue"
+    },
+    "geometry": null,
+    "startAt": "2025-06-02",
+    "endAt": null,
+    "registrationAt": "2025-06-02",
+    "correctionFor": null,
+    "correctedBy": null
+  }
+}

--- a/src/submission-forwarder/receiver-lambda/test/samples/submission.json
+++ b/src/submission-forwarder/receiver-lambda/test/samples/submission.json
@@ -1,0 +1,27 @@
+{
+    "url": "https://example.com/objects/api/v2/objects/5a02c14e-2dea-4dc0-bdef-292595c15d3f",
+    "uuid": "5a02c14e-2dea-4dc0-bdef-292595c15d3f",
+    "type": "https://example.com/objecttypes/api/v2/objecttypes/d3713c2b-307c-4c07-8eaa-c2c6d75869cf",
+    "record": {
+        "index": 1,
+        "typeVersion": 3,
+        "data": {
+            "bsn": "999999333",
+            "kvk": "",
+            "pdf": "https://example.com/documenten/api/v1/enkelvoudiginformatieobjecten/03c047e1-0083-4d8b-8b31-714564b9fdb9",
+            "formName": "Een formuliernaam",
+            "reference": "OF-ABC123",
+            "attachments": [],
+            "networkShare": "//someshare/test",
+            "internalNotificationEmails": [
+                "test@example.com"
+            ]
+        },
+        "geometry": null,
+        "startAt": "2025-06-02",
+        "endAt": null,
+        "registrationAt": "2025-06-02",
+        "correctionFor": null,
+        "correctedBy": null
+    }
+}

--- a/src/submission-forwarder/receiver-lambda/test/taakschema.test.ts
+++ b/src/submission-forwarder/receiver-lambda/test/taakschema.test.ts
@@ -1,0 +1,12 @@
+import * as taak from './samples/esfTaak.json';
+import { EsfTaakSchema } from '../../shared/EsfTaak';
+import { ObjectSchema } from '../../shared/ZgwObject';
+test('parses objects', async() => {
+  expect(ObjectSchema.parse(taak)).toBeTruthy();
+});
+
+test('parses taak in objects', async() => {
+  const object = ObjectSchema.parse(taak);
+  console.debug(object.record.data);
+  expect(EsfTaakSchema.parse(object.record.data)).toBeTruthy();
+});

--- a/src/submission-forwarder/shared/EsfTaak.ts
+++ b/src/submission-forwarder/shared/EsfTaak.ts
@@ -1,0 +1,39 @@
+import z from 'zod';
+
+export const EsfTaakSchema = z.object({
+  soort: z.literal('formtaak'),
+  titel: z.string(),
+  status: z.string(),
+  eigenaar: z.string(),
+  formtaak: z.object({
+    formulier: z.object({
+      soort: z.literal('url'),
+      value: z.string().url(),
+    }),
+    data: z.object({
+      dossiernummer: z.string(),
+      periodenummer: z.string(),
+      email: z.string().email(),
+      telefoon: z.string().optional(),
+    }).passthrough(),
+    verzonden_data: z.object({
+      email: z.string().email(),
+      telefoon: z.string(),
+      inkomstengewijzigd: z.string(),
+      woonsituatiegewijzigd: z.string(),
+      vakantiegewijzigd: z.string(),
+      studiegewijzigd: z.string(),
+      vrijwilligerswerkgewijzigd: z.string(),
+      vermogengewijzigd: z.string(),
+      pdf: z.string(),
+      attachments: z.array(z.string()),
+    }),
+  }),
+  verloopdatum: z.string(),
+  identificatie: z.object({
+    type: z.enum(['bsn', 'kvk']),
+    value: z.string(),
+  }),
+}).passthrough();
+
+export type EsfTaak = z.infer<typeof EsfTaakSchema>;

--- a/src/submission-forwarder/shared/ZgwObject.ts
+++ b/src/submission-forwarder/shared/ZgwObject.ts
@@ -1,0 +1,10 @@
+import z from 'zod';
+
+export const ObjectSchema = z.object({
+  type: z.string().url(),
+  record: z.object({
+    data: z.object({}).passthrough(),
+  }).passthrough(),
+});
+
+export type ZgwObject = z.infer<typeof ObjectSchema>;


### PR DESCRIPTION
For the ability to send on multiple object types to the step function,
we need to support more than the submission object. This adds support
for multiple types.

Concretely, it adds parsing for the esfTaak. The step function will
receive the submission unchanged, the taak will be passed on in an
object that has at least the pdf, attachments and reference key as well.

For determining object type, an SSM parameter is added: This contains
the supported object types, in a format like this:

`<objectType>##<objectTypeUrl>;<objectType>##<objectTypeUrl>`

This only supports for <objectType> values from
`ObjectParser.supportedObjectTypes`. All unsupported objects are
ignored.