### PR TITLE
chore: notificationmail path clickable with spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-import": "^2.32.0",
     "jest": "^29.7.0",
     "jest-junit": "^16",
-    "projen": "^0.95.4",
+    "projen": "^0.95.5",
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"

--- a/src/submission-forwarder/forwarder-lambda/test/forwarder-handler.test.ts
+++ b/src/submission-forwarder/forwarder-lambda/test/forwarder-handler.test.ts
@@ -145,4 +145,32 @@ describe('SubmissionForwarderHandler', () => {
     expect(sqsMock.commandCalls(SendMessageCommand).length).toBe(0);
   });
 
+  it('should include payment information in the notification payload', async () => {
+    await handler.handle(fakeSubmission, ['https://example.com']);
+
+    const sendMessageCalls = sqsMock.commandCalls(SendMessageCommand);
+    expect(sendMessageCalls.length).toBeGreaterThan(0);
+
+    const payload = JSON.parse(sendMessageCalls[0].args[0].input.MessageBody!);
+    // Check that payment info is included in the payload
+    expect(payload.s3Files).toContain('s3://test-bucket/ref123/payment.txt');
+  });
+
+  it('should not include payment information when not provided', async () => {
+    const submissionWithoutPayment = { ...fakeSubmission };
+    delete submissionWithoutPayment.payment;
+
+    sqsMock.reset();
+    sqsMock.on(SendMessageCommand).resolves({});
+
+    await handler.handle(submissionWithoutPayment, ['https://example.com']);
+
+    const sendMessageCalls = sqsMock.commandCalls(SendMessageCommand);
+    expect(sendMessageCalls.length).toBeGreaterThan(0);
+
+    const payload = JSON.parse(sendMessageCalls[0].args[0].input.MessageBody!);
+    // Check that payment info is NOT included in the payload
+    expect(payload.s3Files).not.toContain('s3://test-bucket/ref123/payment.txt');
+  });
+
 });

--- a/src/submission-forwarder/internal-notification-mail-lambda/internalNotificationMail.lambda.ts
+++ b/src/submission-forwarder/internal-notification-mail-lambda/internalNotificationMail.lambda.ts
@@ -66,11 +66,8 @@ function constructNotificationEmail(submission: InternalNotificationMailSubmissi
   return [
     `Er is een nieuwe aanvraag ${submission.formName} binnengekomen met kenmerk ${submission.reference}`,
     (submission.networkShare || submission.monitoringNetworkShare) && 'U kunt de aanvraag op de volgende locaties terugvinden:',
-    replaceForwardSlashes(submission.networkShare),
-    replaceForwardSlashes(submission.monitoringNetworkShare),
-    `Paden met spaties test:`,
-    `<${replaceForwardSlashes(submission.networkShare)}>`,
-    `<${replaceForwardSlashes(submission.monitoringNetworkShare)}>`,
+    submission.networkShare && `<${replaceForwardSlashes(submission.networkShare)}>`,
+    submission.monitoringNetworkShare && `<${replaceForwardSlashes(submission.monitoringNetworkShare)}>`,
   ].join('\n');
 }
 

--- a/src/submission-forwarder/internal-notification-mail-lambda/internalNotificationMail.lambda.ts
+++ b/src/submission-forwarder/internal-notification-mail-lambda/internalNotificationMail.lambda.ts
@@ -68,6 +68,9 @@ function constructNotificationEmail(submission: InternalNotificationMailSubmissi
     (submission.networkShare || submission.monitoringNetworkShare) && 'U kunt de aanvraag op de volgende locaties terugvinden:',
     replaceForwardSlashes(submission.networkShare),
     replaceForwardSlashes(submission.monitoringNetworkShare),
+    `Paden met spaties test:`,
+    `<${replaceForwardSlashes(submission.networkShare)}>`,
+    `<${replaceForwardSlashes(submission.monitoringNetworkShare)}>`,
   ].join('\n');
 }
 

--- a/src/submission-forwarder/internal-notification-mail-lambda/test/internalNotificationMailHandler.test.ts
+++ b/src/submission-forwarder/internal-notification-mail-lambda/test/internalNotificationMailHandler.test.ts
@@ -63,8 +63,8 @@ describe('handler', () => {
 
     expect(bodyToCheck).toContain('TestForm');
     expect(bodyToCheck).toContain('U kunt de aanvraag op de volgende locaties terugvinden');
-    expect(bodyToCheck).toContain('\\server\\path\\to\\folder');
-    expect(bodyToCheck).toContain('\\monitor\\path');
+    expect(bodyToCheck).toContain('<\\\\server\\path\\to\\folder>'); // Double slashes because it escapes the slashes in the string
+    expect(bodyToCheck).toContain('<\\monitor\\path>'); // Double slashes because it escapes the slashes in the string
   });
 
   it('should send an email with an enrichedObject without networkShare', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6351,10 +6351,10 @@ projen@^0.94.2:
     yaml "^2.2.2"
     yargs "^17.7.2"
 
-projen@^0.95.4:
-  version "0.95.4"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.95.4.tgz#bc8a69d5390545d88026a12663c26dcead9f17e6"
-  integrity sha512-KzUg9zIaGEb4iYgvHqo3NwS5VbbgAKYWT+Wo9sLR8tXh0t2K017//DVa+qojMoUiKjjZMNTbfSegzarJDFA9fw==
+projen@^0.95.5:
+  version "0.95.5"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.95.5.tgz#d35c482fcc597800a9057c945a819cf3facf0b73"
+  integrity sha512-ans6XeNortUt2dli5n/5mTdWFhhFzT3Cyx+dJasAOYue1sWA++cnysCQRXP/sSxQdiv8Iua+uaB3fQdihpemZQ==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
Fixes #https://github.com/GemeenteNijmegen/formulieren-migratie/issues/215

Tested on acc in citrix environment. Opens the correct folder with spaces and the folders without spaces.
Simple solution without unnecessary html use.