### PR TITLE
chore: normalize karelstad

### DIFF
--- a/src/submission-forwarder/forwarder-lambda/Handler.ts
+++ b/src/submission-forwarder/forwarder-lambda/Handler.ts
@@ -53,13 +53,13 @@ export class SubmissionForwarderHandler {
     const esb: EsbSubmission = {
       s3Files: s3Files,
       folderName: `${submission.formName}-${submission.reference}`,
-      targetNetworkLocation: submission.networkShare,
+      targetNetworkLocation: normalizeKarelstad(submission.networkShare),
     };
     await this.sendNotificationToQueue(this.options.queueUrl, esb);
 
     // Also send files to monitoring location if provided in submission
     if (submission.monitoringNetworkShare) {
-      const monitoringEsbMessage: EsbSubmission = { ...esb, targetNetworkLocation: submission.monitoringNetworkShare };
+      const monitoringEsbMessage: EsbSubmission = { ...esb, targetNetworkLocation: normalizeKarelstad(submission.monitoringNetworkShare) };
       await this.sendNotificationToQueue(this.options.queueUrl, monitoringEsbMessage);
     }
 
@@ -165,4 +165,15 @@ export class SubmissionForwarderHandler {
     });
     await upload.done();
   }
+}
+/**
+ * Makes sure word karelstad never has uppercase
+ * If the path contains anything other lowercase karelstad with // or \\
+ * it will add another karelstad to the path in the esb processing, which will result in unknown paths
+ * This makes sure accidental non-lowercase karelstads in the variables are dealt with
+ * @param path
+ * @returns
+ */
+export function normalizeKarelstad(path: string): string {
+  return path.replace(/^([\\/]{2})karelstad(?=[\\/]|$)/i, '$1karelstad');
 }

--- a/src/submission-forwarder/forwarder-lambda/test/normalizekarelstad.test.ts
+++ b/src/submission-forwarder/forwarder-lambda/test/normalizekarelstad.test.ts
@@ -1,0 +1,28 @@
+import { normalizeKarelstad } from '../Handler';
+
+describe('normalizeKarelstad', () => {
+  // The expected test strings need escaped slashes
+  // no undefined or null uses expected
+  test.each<[string, string]>([
+    ['//Karelstad/webdata/Webformulieren/', '//karelstad/webdata/Webformulieren/'],
+    ['//karelstad/webdata/Webformulieren/', '//karelstad/webdata/Webformulieren/'],
+    ['//webdata/Webformulieren/', '//webdata/Webformulieren/'],
+
+    ['\\\\KARELSTAD\\share\\x', '\\\\karelstad\\share\\x'],
+    ['\\\\KarelStad', '\\\\karelstad'],
+    ['\\\\webdata\\share', '\\\\webdata\\share'],
+
+    ['//Karelstad\\share\\x', '//karelstad\\share\\x'],
+    ['\\\\KARELSTAD/webdata', '\\\\karelstad/webdata'],
+
+    // should not replace
+    ['//karelstadt/share', '//karelstadt/share'],
+    ['//foo/karelstad/share', '//foo/karelstad/share'],
+    ['Karelstad/webdata', 'Karelstad/webdata'],
+    ['//KARELSTAD', '//karelstad'],
+    ['//Karelstad', '//karelstad'],
+  ])('"%s" -> "%s"', (input, expected) => {
+    expect(normalizeKarelstad(input)).toBe(expected);
+    expect(normalizeKarelstad(expected)).toBe(expected);
+  });
+});


### PR DESCRIPTION
To prevent errors due to typos.
Any uppercases in karelstad in (monitoring)networkshare breaks the path to the correct location.

Tested with forms on acc met OF-JDXSJ3. Ook in mappen en mail gecheckt.

And removed an unused method and mock.
