### PR TITLE
feat: Add API Construct

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -1,0 +1,108 @@
+import { RestApi, SecurityPolicy } from 'aws-cdk-lib/aws-apigateway';
+import { Certificate, CertificateValidation } from 'aws-cdk-lib/aws-certificatemanager';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { IHostedZone, ARecord, RecordTarget, HostedZone } from 'aws-cdk-lib/aws-route53';
+import { ApiGatewayDomain } from 'aws-cdk-lib/aws-route53-targets';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { Configurable, Configuration } from './Configuration';
+import { PrefillDemo } from './prefill-demo/PrefillDemoConstruct';
+import { Statics } from './Statics';
+import { SubmissionForwarder } from './submission-forwarder/SubmissionForwarder';
+
+interface ApiProps extends Configurable {
+  key: Key;
+}
+/**
+ * PrefillApi sets up a REST API with endpoints for prefilling specific
+ * forms. Only used for complex forms, or forms with dynamic data that can't be
+ * accessed using supported patterns.
+ */
+export class Api extends Construct {
+  private hostedzone: IHostedZone;
+  public restApi: RestApi;
+
+  constructor(scope: Construct, id: string, props: ApiProps) {
+    super(scope, id);
+    this.hostedzone = this.importHostedzone();
+    this.setupRestApi(props.key, props.configuration);
+  }
+
+  private setupRestApi(key: Key, configuration: Configuration) {
+    const domain = `form-api.${this.hostedzone.zoneName}`;
+    const cert = new Certificate(this, 'certificate', {
+      domainName: domain,
+      validation: CertificateValidation.fromDns(this.hostedzone),
+    });
+
+    this.restApi = new RestApi(this, 'api', {
+      domainName: {
+        certificate: cert,
+        domainName: domain,
+        securityPolicy: SecurityPolicy.TLS_1_2,
+      },
+    });
+
+    this.createUsagePlan();
+    this.addDnsRecords(domain);
+    this.addRoutes(key);
+    this.addForwarder(configuration, key);
+  }
+
+  private addForwarder(configuration: Configuration, key: Key) {
+    const forwarderResource = this.restApi.root.addResource('submission-forwarder');
+    new SubmissionForwarder(this, 'submission-forwarder', {
+      key,
+      resource: forwarderResource,
+      criticality: configuration.criticality,
+      useVipJzProductionMapping: configuration.branch == 'main', // TODO remove when we can use ZGW to register submisisons in VIP/JZ4ALL
+      logLevel: configuration.logLevel ?? 'INFO',
+      urlSubscriptions: configuration.urlSubscriptions,
+    });
+
+  }
+
+  private addDnsRecords(domain: string) {
+    new ARecord(this, 'a-record', {
+      target: RecordTarget.fromAlias(new ApiGatewayDomain(this.restApi.domainName!)),
+      zone: this.hostedzone,
+      recordName: domain,
+    });
+  }
+
+  private createUsagePlan() {
+    const plan = this.restApi.addUsagePlan('UsagePlan', {
+      description: 'OpenForms supporting infra API gateway',
+      apiStages: [
+        {
+          api: this.restApi,
+          stage: this.restApi.deploymentStage,
+        },
+      ],
+    });
+
+    const key = this.restApi.addApiKey('ApiKey', {
+      description: 'OpenForms supporting infra API key',
+    });
+
+    plan.addApiKey(key);
+  }
+
+  private addRoutes(key: Key) {
+    // Setup a dummy prefill lambda for testing purposes
+    const prefillDemo = this.restApi.root.addResource('prefill-demo');
+    new PrefillDemo(this, 'prefill-demo', {
+      key,
+      resource: prefillDemo,
+    });
+  }
+
+  private importHostedzone() {
+    const accountRootZoneId = StringParameter.valueForStringParameter(this, Statics.accountRootHostedZoneId);
+    const accountRootZoneName = StringParameter.valueForStringParameter(this, Statics.accountRootHostedZoneName);
+    return HostedZone.fromHostedZoneAttributes(this, 'hostedzone', {
+      hostedZoneId: accountRootZoneId,
+      zoneName: accountRootZoneName,
+    });
+  }
+}

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -5,12 +5,10 @@ import { IHostedZone, ARecord, RecordTarget, HostedZone } from 'aws-cdk-lib/aws-
 import { ApiGatewayDomain } from 'aws-cdk-lib/aws-route53-targets';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
-import { Configurable, Configuration } from './Configuration';
 import { PrefillDemo } from './prefill-demo/PrefillDemoConstruct';
 import { Statics } from './Statics';
-import { SubmissionForwarder } from './submission-forwarder/SubmissionForwarder';
 
-interface ApiProps extends Configurable {
+interface ApiProps {
   key: Key;
 }
 /**
@@ -25,10 +23,10 @@ export class Api extends Construct {
   constructor(scope: Construct, id: string, props: ApiProps) {
     super(scope, id);
     this.hostedzone = this.importHostedzone();
-    this.setupRestApi(props.key, props.configuration);
+    this.setupRestApi(props.key);
   }
 
-  private setupRestApi(key: Key, configuration: Configuration) {
+  private setupRestApi(key: Key) {
     const domain = `form-api.${this.hostedzone.zoneName}`;
     const cert = new Certificate(this, 'certificate', {
       domainName: domain,
@@ -46,20 +44,6 @@ export class Api extends Construct {
     this.createUsagePlan();
     this.addDnsRecords(domain);
     this.addRoutes(key);
-    this.addForwarder(configuration, key);
-  }
-
-  private addForwarder(configuration: Configuration, key: Key) {
-    const forwarderResource = this.restApi.root.addResource('submission-forwarder');
-    new SubmissionForwarder(this, 'submission-forwarder', {
-      key,
-      resource: forwarderResource,
-      criticality: configuration.criticality,
-      useVipJzProductionMapping: configuration.branch == 'main', // TODO remove when we can use ZGW to register submisisons in VIP/JZ4ALL
-      logLevel: configuration.logLevel ?? 'INFO',
-      urlSubscriptions: configuration.urlSubscriptions,
-    });
-
   }
 
   private addDnsRecords(domain: string) {

--- a/src/MainStack.ts
+++ b/src/MainStack.ts
@@ -32,7 +32,7 @@ export class MainStack extends Stack {
     this.hostedzone = this.importHostedzone();
     this.api = this.setupRestApi();
 
-    new Api(this, 'form-api', { key: this.key, configuration: props.configuration });
+    const api = new Api(this, 'form-api', { key: this.key });
 
     // Setup a dummy prefill lambda for testing purposes
     const prefillDemo = this.api.root.addResource('prefill-demo');
@@ -43,9 +43,10 @@ export class MainStack extends Stack {
 
     // Setup the submission forwarder
     const forwarderResource = this.api.root.addResource('submission-forwarder');
+    const apiForwarderResource = api.restApi.root.addResource('submission-forwarder');
     new SubmissionForwarder(this, 'submission-forwarder', {
       key: this.key,
-      resource: forwarderResource,
+      resources: [forwarderResource, apiForwarderResource],
       criticality: props.configuration.criticality,
       useVipJzProductionMapping: props.configuration.branch == 'main', // TODO remove when we can use ZGW to register submisisons in VIP/JZ4ALL
       logLevel: props.configuration.logLevel ?? 'INFO',

--- a/src/MainStack.ts
+++ b/src/MainStack.ts
@@ -7,6 +7,7 @@ import { ARecord, HostedZone, IHostedZone, RecordTarget } from 'aws-cdk-lib/aws-
 import { ApiGatewayDomain } from 'aws-cdk-lib/aws-route53-targets';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
+import { Api } from './Api';
 import { Configurable } from './Configuration';
 import { PrefillDemo } from './prefill-demo/PrefillDemoConstruct';
 import { StaticFormDefinitions } from './static-form-definitions/StaticFormDefinitions';
@@ -30,6 +31,8 @@ export class MainStack extends Stack {
     // Hosted zone and api-gateway
     this.hostedzone = this.importHostedzone();
     this.api = this.setupRestApi();
+
+    new Api(this, 'form-api', { key: this.key, configuration: props.configuration });
 
     // Setup a dummy prefill lambda for testing purposes
     const prefillDemo = this.api.root.addResource('prefill-demo');

--- a/src/submission-forwarder/SubmissionForwarder.ts
+++ b/src/submission-forwarder/SubmissionForwarder.ts
@@ -31,7 +31,7 @@ interface SubmissionForwarderOptions {
    * The API Gateway resource to create the
    * endpoint(s) in.
    */
-  resource: Resource;
+  resources: Resource[];
   /**
    * KMS key used for encrypting the logs
    */
@@ -251,7 +251,9 @@ export class SubmissionForwarder extends Construct {
     });
     this.parameters.apikey.grantRead(receiver);
     this.options.key.grantEncryptDecrypt(receiver);
-    this.options.resource.addMethod('POST', new LambdaIntegration(receiver));
+    for (let resource of this.options.resources) {
+      resource.addMethod('POST', new LambdaIntegration(receiver));
+    }
     this.parameters.objectsApikey.grantRead(receiver);
     this.parameters.mijnServicesOpenZaakApiClientId.grantRead(receiver);
     this.parameters.mijnServicesOpenZaakApiClientSecret.grantRead(receiver);
@@ -649,8 +651,9 @@ export class SubmissionForwarder extends Construct {
     this.bucket.grantRead(resubmitLambda);
 
     // Setup API gateway path
-    const resource = this.options.resource.addResource('resubmit');
-    resource.addMethod('POST', new LambdaIntegration(resubmitLambda));
+    for (let resource of this.options.resources) {
+      resource.addResource('resubmit').addMethod('POST', new LambdaIntegration(resubmitLambda));
+    }
   }
 }
 


### PR DESCRIPTION
Introduces the `Api` construct to encapsulate the setup of the REST API.
Additional to the existing API to not break existing functionality. This
can replace the existing setup eventually. Goal: Keep MainStack size
reasonable, have a separate API construct.

*   **`src/Api.ts`**: A new class `Api` is created to manage the API
    *   It sets up the `RestApi`, including domain name configuration
    *   It configures usage plans and API keys
    *   It adds necessary resources like the submission forwarder
        endpoint, prefill demo endpoint
*   **`src/MainStack.ts`**: The `MainStack` now instantiates `Api`