### PR TITLE
feat: Generalize static form definitions setup

### DIFF
--- a/src/MainStack.ts
+++ b/src/MainStack.ts
@@ -53,16 +53,16 @@ export class MainStack extends Stack {
       urlSubscriptions: props.configuration.urlSubscriptions,
     });
 
-    this.setupStaticFromDefinitions();
+    this.setupStaticFromDefinitions([this.api, api.restApi]);
 
   }
 
   /**
    * Bucket and endpoin for serving static form definitions
    */
-  private setupStaticFromDefinitions() {
+  private setupStaticFromDefinitions(apis: RestApi[]) {
     new StaticFormDefinitions(this, 'static-form-definitions', {
-      api: this.api,
+      apis,
       logLevel: this.props.configuration.logLevel ?? 'INFO',
     });
   }

--- a/src/static-form-definitions/StaticFormDefinitions.ts
+++ b/src/static-form-definitions/StaticFormDefinitions.ts
@@ -6,7 +6,7 @@ import { StaticFormDefinitionsFunction } from './lambda/StaticFormDefinitions-fu
 
 export interface StaticFormDefinitionsProps {
   logLevel: string;
-  api: RestApi;
+  apis: RestApi[];
 }
 
 export class StaticFormDefinitions extends Construct {
@@ -27,14 +27,16 @@ export class StaticFormDefinitions extends Construct {
     });
     bucket.grantRead(endpoint);
 
-    const resource = this.props.api.root.addResource('static-form-definitions');
-    resource.addProxy().addMethod('GET', new LambdaIntegration(endpoint));
-
     const loginMock = new LoginMockFunction(this, 'formio-login-mock', {
       description: 'Mock the login endpoint',
     });
-    const resourceMockLogin = this.props.api.root.addResource('formio-login-mock');
-    resourceMockLogin.addProxy().addMethod('POST', new LambdaIntegration(loginMock));
 
+    for (let api of props.apis) {
+      const resource = api.root.addResource('static-form-definitions');
+      resource.addProxy().addMethod('GET', new LambdaIntegration(endpoint));
+
+      const resourceMockLogin = api.root.addResource('formio-login-mock');
+      resourceMockLogin.addProxy().addMethod('POST', new LambdaIntegration(loginMock));
+    }
   }
 }


### PR DESCRIPTION
The setup for static form definitions has been generalized to accept an array of APIs instead of a single API. This change allows the system to configure multiple API endpoints when setting up static form definitions, preparing for swap.

*   `MainStack.setupStaticFromDefinitions` signature was updated to accept
    `RestApi[]`. It now passes both `this.api` and `api.restApi` to the
    static definitions constructor.
*   `StaticFormDefinitionsProps` in `StaticFormDefinitions.ts` now expects
    `apis: RestApi[]`.
*   The resource creation logic in `StaticFormDefinitions` was refactored to
    iterate over the `props.apis` array, creating necessary proxy resources
    for both static definitions and the login mock for every provided API.

Required for #711 