### PR TITLE
feat: initialize Bruno API collection

### DIFF
--- a/bruno/Open Forms management/.gitignore
+++ b/bruno/Open Forms management/.gitignore
@@ -1,0 +1,9 @@
+# Secrets
+.env*
+
+# Dependencies
+node_modules
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/bruno/Open Forms management/environments/Open Forms management - accp.yml
+++ b/bruno/Open Forms management/environments/Open Forms management - accp.yml
@@ -1,0 +1,4 @@
+name: Open Forms management - accp
+variables:
+  - name: baseUrl
+    value: https://form-api.open-forms-accp.csp-nijmegen.nl

--- a/bruno/Open Forms management/opencollection.yml
+++ b/bruno/Open Forms management/opencollection.yml
@@ -1,0 +1,10 @@
+opencollection: 1.0.0
+
+info:
+  name: Open Forms management
+bundled: false
+extensions:
+  bruno:
+    ignore:
+      - node_modules
+      - .git

--- a/bruno/Open Forms management/prefill/folder.yml
+++ b/bruno/Open Forms management/prefill/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: prefill
+  type: folder
+  seq: 1
+
+request:
+  auth: inherit

--- a/bruno/Open Forms management/prefill/standplaatsvergunning.yml
+++ b/bruno/Open Forms management/prefill/standplaatsvergunning.yml
@@ -1,0 +1,35 @@
+info:
+  name: standplaatsvergunning
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: "{{baseUrl}}/prefill/standplaatsvergunning?watWiltUDoen=koningsdag&startdatum=&einddatum=&tijdStartConcerten=&tijdEindeConcerten="
+  params:
+    - name: watWiltUDoen
+      value: koningsdag
+      type: query
+    - name: startdatum
+      value: ""
+      type: query
+    - name: einddatum
+      value: ""
+      type: query
+    - name: tijdStartConcerten
+      value: ""
+      type: query
+    - name: tijdEindeConcerten
+      value: ""
+      type: query
+    - name: standplaatsOpties
+      value: "true"
+      type: query
+      disabled: true
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5


### PR DESCRIPTION
This commit initializes a new Bruno API collection for Open Forms management.

- Adds .gitignore to prevent tracking environment files and dependencies.
- Adds an 'accp' environment with a baseUrl variable.
- Adds the root collection configuration file.
- Adds a 'prefill' folder structure.
- Adds a 'standplaatsvergunning' request that uses the baseUrl and
  query parameters for prefill functionality.
