### PR TITLE
feat: ZGWclientfactory JWT refreshes and caching 

### DIFF
--- a/src/submission-forwarder/shared/ZgwClientFactory.ts
+++ b/src/submission-forwarder/shared/ZgwClientFactory.ts
@@ -8,7 +8,7 @@ import { ObjectsApiClient } from './ObjectsApiClient';
 /**
  * Standard max token cache time before renewal
  */
-const ZGW_TOKEN_CACHE_TTL_MS = 2 * 60 * 1000; // 1 minute in millisecond for testing purposes not too long
+export const ZGW_TOKEN_CACHE_TTL_MS = 15 * 60 * 1000; // 15 minuten
 /**
  * CRS headers needed in some of the zgw clients
  */

--- a/src/submission-forwarder/shared/ZgwClientFactory.ts
+++ b/src/submission-forwarder/shared/ZgwClientFactory.ts
@@ -8,7 +8,7 @@ import { ObjectsApiClient } from './ObjectsApiClient';
 /**
  * Standard max token cache time before renewal
  */
-const ZGW_TOKEN_CACHE_TTL_MS = 1 * 60 * 1000; // 1 minute in millisecond for testing purposes not too long
+const ZGW_TOKEN_CACHE_TTL_MS = 2 * 60 * 1000; // 1 minute in millisecond for testing purposes not too long
 /**
  * CRS headers needed in some of the zgw clients
  */
@@ -33,38 +33,20 @@ export class ZgwClientFactory {
   constructor(private readonly credentials: ZgwClientFactoryCredentials) { }
 
   async getCatalogiClient(baseUrl: string) {
-    const token = await this.createToken();
     const client = new CatalogiHttpClient({
       baseURL: baseUrl,
       format: 'json',
-      async securityWorker(securityData: any) {
-        return {
-          headers: {
-            'Authorization': `Bearer ${securityData?.token}`,
-            'Content-Crs': 'EPSG:4326',
-            'Accept-Crs': 'EPSG:4326',
-          },
-        };
-      },
+      securityWorker: () => this.createSecurityParameters(true),
     });
-    client.setSecurityData({ token });
     return client;
   }
 
   async getDocumentenClient(baseUrl: string) {
-    const token = await this.createToken();
     const client = new DocumentenHttpClient({
       baseURL: baseUrl,
       format: 'json',
-      async securityWorker(securityData: any) {
-        return {
-          headers: {
-            Authorization: `Bearer ${securityData?.token}`,
-          },
-        };
-      },
+      securityWorker: () => this.createSecurityParameters(false),
     });
-    client.setSecurityData({ token });
     return client;
   }
 
@@ -74,7 +56,6 @@ export class ZgwClientFactory {
       format: 'json',
       securityWorker: () => this.createSecurityParameters(true),
     });
-
     return client;
   }
 
@@ -101,6 +82,7 @@ export class ZgwClientFactory {
     const cachedToken = this.zgwTokenCache;
     const now = Date.now();
     if (cachedToken && now < cachedToken.refreshAt) {
+      console.debug('ZGW JWT cache used.', { currentIat: cachedToken?.issuedAt, refreshAt: cachedToken?.refreshAt });
       return cachedToken.token;
     }
     const token = await this.createToken();

--- a/src/submission-forwarder/shared/ZgwClientFactory.ts
+++ b/src/submission-forwarder/shared/ZgwClientFactory.ts
@@ -5,17 +5,30 @@ import { AWS } from '@gemeentenijmegen/utils';
 import * as jwt from 'jsonwebtoken';
 import { ObjectsApiClient } from './ObjectsApiClient';
 
+/**
+ * Standard max token cache time before renewal
+ */
+const ZGW_TOKEN_CACHE_TTL_MS = 1 * 60 * 1000; // 1 minute in millisecond for testing purposes not too long
+/**
+ * CRS headers needed in some of the zgw clients
+ */
+const ZGW_CRS_HEADERS = { 'Content-Crs': 'EPSG:4326', 'Accept-Crs': 'EPSG:4326' } as const;
 export interface ZgwClientFactoryCredentials {
   clientIdSsm: string;
   clientSecretArn: string;
   objectsApikeyArn: string;
 }
 
+/**
+ * Can create JWT tokens
+ * Has an async callback securityworker that uses the generated JWT token and renews it once it is invalid
+ */
 export class ZgwClientFactory {
 
   private clientId?: string;
   private clientSecret?: string;
   private objectsApikey?: string;
+  private zgwTokenCache?: { token: string; issuedAt: number; refreshAt: number };
 
   constructor(private readonly credentials: ZgwClientFactoryCredentials) { }
 
@@ -56,21 +69,12 @@ export class ZgwClientFactory {
   }
 
   async getZakenClient(baseUrl: string) {
-    const token = await this.createToken();
     const client = new ZakenHttpClient({
       baseURL: baseUrl,
       format: 'json',
-      async securityWorker(securityData: any) {
-        return {
-          headers: {
-            'Authorization': `Bearer ${securityData?.token}`,
-            'Content-Crs': 'EPSG:4326',
-            'Accept-Crs': 'EPSG:4326',
-          },
-        };
-      },
+      securityWorker: () => this.createSecurityParameters(true),
     });
-    client.setSecurityData({ token });
+
     return client;
   }
 
@@ -82,6 +86,31 @@ export class ZgwClientFactory {
     return new ObjectsApiClient({ apikey: this.objectsApikey });
   }
 
+
+  private async createSecurityParameters(includeCrsHeaders: boolean) {
+    console.debug('createSecurityParameters callback function');
+    const token = await this.getValidToken();
+    return { headers: { Authorization: `Bearer ${token}`, ...(includeCrsHeaders ? ZGW_CRS_HEADERS : {}) } };
+  }
+  /**
+ * Check if a token exists and the token is younger than the ttl
+ * This check prevents the use of tokens with an IAT (issuance at) older than the set TTL
+ * @returns a valid JWT token
+ */
+  private async getValidToken(): Promise<string> {
+    const cachedToken = this.zgwTokenCache;
+    const now = Date.now();
+    if (cachedToken && now < cachedToken.refreshAt) {
+      return cachedToken.token;
+    }
+    const token = await this.createToken();
+    const issuedAt = Math.floor(now / 1000); // epoch in seconds
+    const refreshAt = now + ZGW_TOKEN_CACHE_TTL_MS; // epoch in milliseconds + TTL in milliseconds
+
+    this.zgwTokenCache = { token, issuedAt, refreshAt };
+    console.log('ZGW JWT cache refreshed.', { reason: cachedToken ? 'ttl-expired' : 'cache-empty', previousIat: cachedToken?.issuedAt, currentIat: issuedAt, refreshAt });
+    return token;
+  }
   /**
    * Generates a new JWT token for authentication.
    */
@@ -93,13 +122,13 @@ export class ZgwClientFactory {
     return jwt.sign(
       {
         iss: this.clientId,
-        iat: Math.floor(Date.now() / 1000),
+        iat: Math.floor(Date.now() / 1000), // epoch in seconds
         client_id: this.clientId,
         user_id: this.clientId,
         user_representation: this.clientId,
       },
       this.clientSecret,
-      { expiresIn: '12h' }, // Set token expiration to 12 hours
+      { expiresIn: '1h' }, // Set token expiration to 1 hour
     );
   }
 

--- a/src/submission-forwarder/shared/test/ZgwClientFactory.test.ts
+++ b/src/submission-forwarder/shared/test/ZgwClientFactory.test.ts
@@ -1,0 +1,111 @@
+import { AWS } from '@gemeentenijmegen/utils';
+import * as jwt from 'jsonwebtoken';
+import { ZgwClientFactoryCredentials, ZgwClientFactory, ZGW_TOKEN_CACHE_TTL_MS } from '../ZgwClientFactory';
+
+
+jest.mock('@gemeentenijmegen/utils', () => ({
+  AWS: {
+    getParameter: jest.fn(),
+    getSecret: jest.fn(),
+  },
+}));
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn(),
+}));
+
+const START_TIME = new Date('2026-06-18T10:00:00.000Z');
+
+const credentials: ZgwClientFactoryCredentials = {
+  clientIdSsm: '/zgw/client-id',
+  clientSecretArn: 'arn:aws:secretsmanager:client-secret',
+  objectsApikeyArn: 'arn:aws:secretsmanager:objects-api-key',
+};
+
+
+// Anders gaat hij moeilijk doen om de types bij het nadoen van de zgwclientfactory
+type TestableZgwClientFactory = {
+  getValidToken(): Promise<string>;
+};
+
+// Om de private functie aanroepen te kunnen doen
+function getValidToken(factory: ZgwClientFactory): Promise<string> {
+  return (
+    factory as unknown as TestableZgwClientFactory
+  ).getValidToken();
+}
+
+describe('ZgwClientFactory token cache', () => {
+  const getParameterMock = AWS.getParameter as jest.Mock;
+  const getSecretMock = AWS.getSecret as jest.Mock;
+  const signMock = jwt.sign as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers({ now: START_TIME });
+
+    getParameterMock.mockResolvedValue('client-id');
+
+    getSecretMock
+      .mockResolvedValueOnce('client-secret')
+      .mockResolvedValueOnce('objects-api-key');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('maakt een JWT met de geladen credentials en de huidige tijd', async () => {
+    signMock.mockReturnValue('token-1');
+
+    const factory = new ZgwClientFactory(credentials);
+
+    await expect(getValidToken(factory)).resolves.toBe('token-1');
+
+    expect(signMock).toHaveBeenCalledTimes(1);
+    expect(signMock).toHaveBeenCalledWith(
+      {
+        iss: 'client-id',
+        iat: Math.floor(START_TIME.getTime() / 1000),
+        client_id: 'client-id',
+        user_id: 'client-id',
+        user_representation: 'client-id',
+      },
+      'client-secret',
+      {
+        expiresIn: '1h',
+      },
+    );
+  });
+
+  it('hergebruikt het token binnen de TTL en vernieuwt het exact op de TTL', async () => {
+    signMock
+      .mockReturnValueOnce('token-1')
+      .mockReturnValueOnce('token-2');
+
+    const factory = new ZgwClientFactory(credentials);
+
+    // Lege cache: token aanmaken.
+    await expect(getValidToken(factory)).resolves.toBe('token-1');
+
+    // Eén milliseconde vóór refreshAt: bestaand token gebruiken.
+    jest.setSystemTime(
+      new Date(START_TIME.getTime() + ZGW_TOKEN_CACHE_TTL_MS - 1),
+    );
+
+    await expect(getValidToken(factory)).resolves.toBe('token-1');
+    expect(signMock).toHaveBeenCalledTimes(1);
+
+    // Exact op refreshAt: token vernieuwen.
+    jest.setSystemTime(
+      new Date(START_TIME.getTime() + ZGW_TOKEN_CACHE_TTL_MS),
+    );
+
+    await expect(getValidToken(factory)).resolves.toBe('token-2');
+    expect(signMock).toHaveBeenCalledTimes(2);
+
+    // Credentials blijven na de eerste keer gecachet.
+    expect(getParameterMock).toHaveBeenCalledTimes(1);
+    expect(getSecretMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Fixes #https://github.com/GemeenteNijmegen/devops/issues/1381
Getest op acceptatie door merdere step functions met aanroepen (15-20 in 1 minuut) achter elkaar aan te roepen (met tijdelijk kortere TTL). Ook gedrag getest met meerdere Lambda instances tegelijkertijd.

- JWT wordt niet meer statisch meegegeven
- Securityworker in http clients krijgt call back functie 
- - die JWT opnieuw aanmaakt
- - JWT cacht
- - Iedere call checkt of een refresh van het token nodig is (15 minuten ttl)

- Logging om refresh token te kunnen zien op prod
- Debug logging voor acceptatie om gedrag te bevestigen